### PR TITLE
Show modal form toolbox submit button.

### DIFF
--- a/js/atrium_folders_modal_toolbox.js
+++ b/js/atrium_folders_modal_toolbox.js
@@ -78,6 +78,9 @@
       .addClass('modal-toolbox-processed')
       .click(Drupal.AtriumFolders.ModalToolbox.clickAjaxLink);
 
+    // Show submit buttons in modal form (hidden by itweak_upload behaviors)
+    $('#modal-content .buttons input[type="submit"]:not(.modal-toolbox-processed)').show().addClass('modal-toolbox-processed');
+
     if ($(context).attr('id') == 'modal-content') {
       // Bind submit links in the modal form.
       $('form:not(.modal-toolbox-processed)', context)


### PR DESCRIPTION
FIX 'Turning on jquery update with atrium 1.0 make Folders inputs invisble' (#15) 
